### PR TITLE
fix FD_ISSET bool issue 

### DIFF
--- a/libraries/httpd/httpd.c
+++ b/libraries/httpd/httpd.c
@@ -548,8 +548,8 @@ void mwHttpLoop(HttpParam *hp, uint32_t timeout)
 		if (!socket) continue;
 
 		// get read/write status for socket
-		bRead = FD_ISSET(socket, &fdsSelectRead);
-		bWrite = FD_ISSET(socket, &fdsSelectWrite);
+		bRead = FD_ISSET_BOOL(socket, &fdsSelectRead);
+		bWrite = FD_ISSET_BOOL(socket, &fdsSelectWrite);
 
 		if (bRead || bWrite) {
 			iRc = -1;
@@ -1112,7 +1112,7 @@ int _mwProcessReadSocket(HttpParam* hp, HttpSocket* phsSocket)
 
 	if (!hp->pxUrlHandler || !_mwCheckUrlHandlers(hp,phsSocket))
 		SETFLAG(phsSocket,FLAG_DATA_FILE);
-		
+
 	// set state to SENDING (actual sending will occur on next select)
 	CLRFLAG(phsSocket,FLAG_RECEIVING)
 	if (phsSocket->request.iHttpVer == 0) {
@@ -1162,7 +1162,7 @@ void _mwCloseSocket(HttpParam* hp, HttpSocket* phsSocket)
 	if (phsSocket->fp) {
 		fclose(phsSocket->fp);
 		phsSocket->fp = 0;
-		hp->stats.openedFileCount--;	
+		hp->stats.openedFileCount--;
 	}
 	if (phsSocket->request.pucPayload) {
 		free(phsSocket->request.pucPayload);

--- a/libraries/httpd/httpd.h
+++ b/libraries/httpd/httpd.h
@@ -12,6 +12,9 @@
 #include <time.h>
 #include "httppil.h"
 
+
+#define	FD_ISSET_BOOL(n, p)	((FD_ISSET(n,p)) >> ((n) % NFDBITS))
+
 #ifndef min
 #define min(x,y) (x>y?y:x)
 #endif


### PR DESCRIPTION
I wasn't able to connect to the HTTP server. After digging in the code, I found that `bool bRead/bWrite = FD_ISSET(...)` was not set correctly (within httpd.c). Even though FD_ISSET returned a value > 0, bRead was set to false. By defining FD_ISSET_BOOL returning a shifted FD_ISSET, bRead/bWrite is set correctly. 