### PR TITLE
Fix crash for unavailable GPS data

### DIFF
--- a/firmware_v5/datalogger/datalogger.ino
+++ b/firmware_v5/datalogger/datalogger.ino
@@ -169,9 +169,13 @@ int handlerLiveData(UrlHandlerParam* param)
     buf[n++] = '}';
 #endif
 #if USE_GPS
-    n += snprintf(buf + n, bufsize - n, ",\"gps\":{\"date\":%u,\"time\":%u,\"lat\":%f,\"lng\":%f,\"alt\":%f,\"speed\":%f,\"sat\":%u,\"sentences\":%u,\"errors\":%u}",
-        gd->date, gd->time, gd->lat, gd->lng, gd->alt, gd->speed, gd->sat,
-        gd->sentences, gd->errors);
+    if (lastGPStime){
+        n += snprintf(buf + n, bufsize - n, ",\"gps\":{\"date\":%u,\"time\":%u,\"lat\":%f,\"lng\":%f,\"alt\":%f,\"speed\":%f,\"sat\":%u,\"sentences\":%u,\"errors\":%u}",
+            gd->date, gd->time, gd->lat, gd->lng, gd->alt, gd->speed, gd->sat,
+            gd->sentences, gd->errors);
+    } else {
+        n += snprintf(buf + n, bufsize - n, ",\"gps\":{\"ready\":\"no\"}");
+    }
 #endif
     buf[n++] = '}';
     param->contentLength = n;


### PR DESCRIPTION
When testing indoor, it often happens that GPS does not initialize. In this situation, [accessing live data crashes the webserver](https://github.com/stanleyhuangyc/Freematics/issues/59).
Changed to handle the case gracefully and inform the client.