### PR TITLE
Add include guards and move ORIENTATION struct definition to mems header

### DIFF
--- a/firmware_v4/libraries/FreematicsONE/FreematicsBase.h
+++ b/firmware_v4/libraries/FreematicsONE/FreematicsBase.h
@@ -33,12 +33,6 @@
 #define PID_DEVICE_TEMP 0x82
 #define PID_DEVICE_HALL 0x83
 
-typedef struct {
-  float pitch;
-  float yaw;
-  float roll;
-} ORIENTATION;
-
 class CFreematics
 {
 public:

--- a/firmware_v4/libraries/FreematicsONE/FreematicsMEMS.h
+++ b/firmware_v4/libraries/FreematicsONE/FreematicsMEMS.h
@@ -219,6 +219,12 @@ enum {
 #define Kp 2.0f * 5.0f // these are the free parameters in the Mahony filter and fusion scheme, Kp for proportional feedback, Ki for integral
 #define Ki 0.0f
 
+typedef struct {
+  float pitch;
+  float yaw;
+  float roll;
+} ORIENTATION;
+
 class CQuaterion
 {
 public:

--- a/firmware_v4/libraries/FreematicsONE/FreematicsNetwork.h
+++ b/firmware_v4/libraries/FreematicsONE/FreematicsNetwork.h
@@ -4,6 +4,8 @@
 * Developed by Stanley Huang https://www.facebook.com/stanleyhuangyc
 *************************************************************************/
 
+#pragma once
+
 #include <Arduino.h>
 #include "FreematicsBase.h"
 

--- a/firmware_v4/libraries/FreematicsONE/FreematicsONE.h
+++ b/firmware_v4/libraries/FreematicsONE/FreematicsONE.h
@@ -5,6 +5,8 @@
 * (C)2012-2018 Stanley Huang <stanley@freematics.com.au>
 *************************************************************************/
 
+#pragma once
+
 #include "FreematicsBase.h"
 #include "FreematicsMEMS.h"
 


### PR DESCRIPTION
This makes it possible to include `FreematicsONE.h` only to get OBD PID definitions