### PR TITLE
Don't split received messages

### DIFF
--- a/firmware_v4/libraries/FreematicsONE/FreematicsONE.cpp
+++ b/firmware_v4/libraries/FreematicsONE/FreematicsONE.cpp
@@ -467,6 +467,7 @@ int COBDSPI::receive(char* buffer, int bufsize, unsigned int timeout)
 		debugOutput("RECV TIMEOUT");
 	}
 #endif
+	n = max(n-2, 0); // for some reason the last two chars are always '>\t', remove those to not break transmissions...
 	buffer[n] = 0;
 #ifdef DEBUG
 	if (m_target == TARGET_OBD) {


### PR DESCRIPTION
I had it quite often that "xbee" communication is so slow or unfortunately timed that messages get split in two. Currently here are two garbage bytes that are appended to every message. That's why often messages from the GSM module can't be parsed correctly.

This PR fixes the incorrect splitting by removing the last two bytes form every transmission.