### PR TITLE
restore missing timestamp

### DIFF
--- a/firmware_v5/datalogger/datalogger.h
+++ b/firmware_v5/datalogger/datalogger.h
@@ -160,10 +160,6 @@ public:
         m_file.write((uint8_t*)buf, len);
         m_file.write('\n');
     }
-    void setTimestamp(uint32_t ts)
-    {
-        m_dataTime = ts;
-    }
 private:
     uint32_t m_size = 0;
 };


### PR DESCRIPTION
The virtual setTimestamp method in the base FileLogger class already handles the timestamp nicely, so the fix for #91 is simply to remove the barebones implementation from the SDLogger class.
Now the first record of each block is always "PID" 0 with the timestamp.
Please consider merging, thanks.

