### PR TITLE
Update the invalid coordinates filter to be on the same scale

### DIFF
--- a/libraries/FreematicsPlus/FreematicsPlus.cpp
+++ b/libraries/FreematicsPlus/FreematicsPlus.cpp
@@ -597,7 +597,7 @@ bool FreematicsESP32::gpsGetData(GPS_DATA** pgd)
         } while(0);
         if (good && (gpsData->lat || gpsData->lng)) {
             // filter out invalid coordinates
-            good = (abs(lat - gpsData->lat * 1000000) < 100000 && abs(lng - gpsData->lng * 1000000) < 100000);
+            good = (abs(lat * 1000000 - gpsData->lat * 1000000) < 100000 && abs(lng * 1000000 - gpsData->lng * 1000000) < 100000);
         }
         if (!good) return false;
         gpsData->lat = lat;


### PR DESCRIPTION
The lat and lng variables have the dd.dddddd format, and that's what the gpsData->lat and gpsData->lng is assigned if the good flag is true. So we must make the comparison on the same scale. At the moment, if lat (or lng) is 51.123456 and the gpsData->lat is 51.100000, the formula will be 51.123456 - 51.100000 * 1000000, while it should be on the same scale, like 51.123456 * 1000000 - 51.100000 * 100000 and then the formula makes sense. The same formula is user on the else branch of the outer if statement, but there it makes sens because the gpsData->lat = lat/1000000.