### PR TITLE
Make telelogger example compilable

### DIFF
--- a/firmware_v5/telelogger/platformio.ini
+++ b/firmware_v5/telelogger/platformio.ini
@@ -9,8 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-;platform=espressif32
-platform=https://github.com/platformio/platform-espressif32.git#feature/stage
+platform=espressif32
 build_flags = -DBOARD_HAS_PSRAM
 board=esp32dev
 framework=arduino


### PR DESCRIPTION
The `platformio.ini` references a non-existing branch of the `platform-espressif32` repository, thus giving the error

```
fatal: Remote branch feature/stage not found in upstream origin
```

making it unable to compile. This commit removes that line and switches to the standard espressif32 mainline platform.

The same error may also be contained in other `platformio.ini` files, but this is the one that was reported in the [PIO forum](https://community.platformio.org/t/warning-could-not-find-remote-branch-feature-stage-to-clone/16686).