### PR TITLE
Add buzzer config with default true

### DIFF
--- a/firmware_v5/telelogger/config.h
+++ b/firmware_v5/telelogger/config.h
@@ -46,6 +46,13 @@
 #define MAX_OBD_ERRORS 3
 
 /**************************************
+* Buzzer configurations
+**************************************/
+#ifndef ENABLE_BUZZER
+#define ENABLE_BUZZER 1
+#endif
+
+/**************************************
 * Networking configurations
 **************************************/
 #ifndef NET_DEVICE

--- a/firmware_v5/telelogger/config.xml
+++ b/firmware_v5/telelogger/config.xml
@@ -2,6 +2,7 @@
 <config>
 <target name="Freematics ONE+" board="esp32 esp32_16m esp32c3" monitor_baudrate="115200">
   <define name="Enable OBD" type="bool" const="ENABLE_OBD" default="true"/>
+  <define name="Enable Buzzer" type="bool" const="ENABLE_BUZZER" default="true"/>
   <define name="Enable Motion Sensor" type="bool" const="ENABLE_MEMS" default="true"/>
   <define name="GNSS">
     <option name="None" const="GNSS=GNSS_NONE"/>

--- a/firmware_v5/telelogger/telelogger.ino
+++ b/firmware_v5/telelogger/telelogger.ino
@@ -470,11 +470,13 @@ void printTime()
 *******************************************************************************/
 void initialize()
 {
-    // turn on buzzer at 2000Hz frequency 
+#if ENABLE_BUZZER
+  // turn on buzzer at 2000Hz frequency 
   sys.buzzer(2000);
   delay(100);
   // turn off buzzer
   sys.buzzer(0);
+#endif
 
   // dump buffer data
   bufman.purge();


### PR DESCRIPTION
**Intention:**
I'm basically using the hardware with traccar as security device.
Such case it's good idea to turn off buffer in order to hide it properly.

**What this PR contains:**
In this PR I've added a config to turn off buzzer (default: enabled).

**How it's tested:**
Compiled the code with and without flag and checked the buzzer noise manually.

Since I'm using this hardware every day and found couple of improvement possibilities
I'm intended to fix them in public to help the community to use this device properly.
