### PR TITLE
fix: buzzer ignored `freq` argument

### DIFF
--- a/libraries/FreematicsPlus/FreematicsPlus.cpp
+++ b/libraries/FreematicsPlus/FreematicsPlus.cpp
@@ -843,7 +843,7 @@ void FreematicsESP32::buzzer(int freq)
 {
 #ifdef PIN_BUZZER
     if (freq) {
-        ledcWriteTone(0, 2000);
+        ledcWriteTone(0, freq);
         ledcWrite(0, 255);
     } else {
         ledcWrite(0, 0);


### PR DESCRIPTION
It was pinned to 2000Hz, and was used only to disable buzzer if was 0.