### PR TITLE
FIX fw5-telelogger.showStats() regression when ENABLE_OLED

### DIFF
--- a/firmware_v5/telelogger/telelogger.ino
+++ b/firmware_v5/telelogger/telelogger.ino
@@ -582,7 +582,7 @@ void showStats()
   Serial.println();
 #if ENABLE_OLED
   oled.setCursor(0, 2);
-  oled.println(timestr);
+  oled.println(buf);
   oled.setCursor(0, 5);
   oled.printInt(teleClient.txCount, 2);
   oled.setCursor(80, 5);


### PR DESCRIPTION
Stanley's fe345f9 on 9 Dec 2021 broke `showSstats()` when ENABLE_OLED is defined,
due to forgotten renaming of the buffer variable from `timestr` -> `buf`.