### PR TITLE
feat(teleserver, build) MAX_CHANNELS set from CLI

### DIFF
--- a/server/teleserver/Makefile
+++ b/server/teleserver/Makefile
@@ -1,10 +1,12 @@
+# Can track MAX 16 devices simultaneously
+MAX_CHANNELS ?= 16
 CC=gcc
 CFLAGS=-O3 -Wunused-result
 HEADERS = httpint.h httpapi.h
 TARGET = teleserver
 OBJS += teleserver.o udpserver.o teletrips.o telebroker.o data2kml.o processpil.o httpd/httppil.o httpd/httpd.o cJSON/cJSON.o cJSON/cJSON_Utils.o libb64/cdecode.o libb64/cencode.o jsonconfig.o
 
-CFLAGS+=-DMAX_CHANNELS=16
+CFLAGS+=-DMAX_CHANNELS=$(MAX_CHANNELS)
 CFLAGS+=-Ihttpd -Ilibb64 -IcJSON
 LDFLAGS = -lm
 


### PR DESCRIPTION
If my understand is correct, the _build-time_ default value `MAX_CHANNELS=16` limits the maximum simultaneous devices that can transmit data to the `teleserver`.
Hence it's a quite frequent need to increase this value for those of use with multiple devices.

Currently it is impossible to change `MAX_CHANNELS` without modifying the `Makefile` file (under git-control),
which is is error-prone when transferring server installations.

With the changes here, it is possible to use this `make` command to increase the channels on build-time:

```bash
make MAX_CHANNELS=64
```
