### PR TITLE
Fix compile error for datalogger

### DIFF
--- a/firmware_v5/datalogger/config.h
+++ b/firmware_v5/datalogger/config.h
@@ -53,3 +53,6 @@
 #define GPS_SERIAL_BAUDRATE 115200L
 // motion detection
 #define WAKEUP_MOTION_THRESHOLD 0.3 /* G */
+
+#define STATS_INTERVAL 1000 /* ms */
+#define MAX_OBD_RETRY_INTERVAL 10 /* ms */

--- a/firmware_v5/datalogger/datalogger.ino
+++ b/firmware_v5/datalogger/datalogger.ino
@@ -922,7 +922,7 @@ void loop()
             logger.clearState(STATE_OBD_READY);
             logger.setState(STATE_STANDBY);
         }
-    } else if (millis() - lastOBDCheckTime >= OBD_RETRY_INTERVAL) {
+    } else if (millis() - lastOBDCheckTime >= MAX_OBD_RETRY_INTERVAL) {
         Serial.print("OBD:");
         if (obd.init()) {
             logger.setState(STATE_OBD_READY);


### PR DESCRIPTION
Since [this commit](https://github.com/stanleyhuangyc/Freematics/commit/3efa8ee237fa388fa826fbbd6ea21c60ffa59b6f) compilation of datalogger is broken with the following errors:

```
C:\Users\datwelk\AppData\Local\Temp/FreematicsBuilder/datalogger.ino.cpp:925:47: error: 'MAX_OBD_RETRY_INTERVAL' was not declared in this scope
             logger.setState(STATE_STANDBY);

C:\Users\datwelk\AppData\Local\Temp/FreematicsBuilder/datalogger.ino.cpp:964:37: error: 'STATS_INTERVAL' was not declared in this scope
```

This commit fixes the error by defining/using the relevant variables.