### PR TITLE
Add constants for OBD stats and retry interval

### DIFF
--- a/firmware_v5/datalogger/config.h
+++ b/firmware_v5/datalogger/config.h
@@ -13,6 +13,8 @@
 #ifndef HAVE_CONFIG
 // enable(1)/disable(0) serial data output
 #define ENABLE_SERIAL_OUT 0
+// interval for show stats when serial is disabled
+#define STATS_INTERVAL 10000 /* ms */
 // specify storage type
 #define STORAGE STORAGE_SD
 #endif
@@ -53,3 +55,9 @@
 #define GPS_SERIAL_BAUDRATE 115200L
 // motion detection
 #define WAKEUP_MOTION_THRESHOLD 0.3 /* G */
+
+/**************************************
+* OBD-II configurations
+**************************************/
+// interval to retry OBD state check
+#define OBD_RETRY_INTERVAL 10000 /* ms */


### PR DESCRIPTION
Fix two build errors in DataLogger related to undeclared constants

datalogger.ino:925:47: error: 'OBD_RETRY_INTERVAL' was not declared in this scope
datalogger.ino:964:37: error: 'STATS_INTERVAL' was not declared in this scope