### PR TITLE
Fix plaintext being used when TLS expected (HTTPS)

### DIFF
--- a/libraries/FreematicsPlus/FreematicsNetwork.h
+++ b/libraries/FreematicsPlus/FreematicsNetwork.h
@@ -10,6 +10,7 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <WiFiUdp.h>
+#include <WiFiClientSecure.h>
 
 #include "esp_system.h"
 #include "esp_log.h"
@@ -96,6 +97,8 @@ public:
     char* receive(char* buffer, int bufsize, int* pbytes = 0, unsigned int timeout = HTTP_CONN_TIMEOUT);
 private:
     WiFiClient client;
+    WiFiClientSecure secureClient;
+    bool m_useSSL = false;
 };
 
 typedef enum {


### PR DESCRIPTION
I'm working towards fixing the issue described in #211. When `PROTOCOL_HTTPS_GET` or `PROTOCOL_HTTPS_POST` are configured, traffic is sent plaintext over TCP443 to the server. I am also fixing other issues that I've come across concerning GET/POST via WiFi and cellular.