### PR TITLE
telelogger: fix data interval time units and add optional RPM ignition indicator

### DIFF
--- a/firmware_v5/telelogger/config.h
+++ b/firmware_v5/telelogger/config.h
@@ -74,6 +74,18 @@
 // maximum consecutive OBD access errors before entering standby
 #define MAX_OBD_ERRORS 3
 
+// Encode ignition state into the RPM PID (0x10C) so it can be used as a reliable
+// ignition indicator (e.g. by Traccar via "rpm > 0"):
+//   1 = engine auto-stop (ECU alive, RPM 0) is reported as RPM 1, and ignition
+//       OFF (ECU not responding) is reported as RPM 0. rpm >= 1 means ON.
+//   0 = original behavior (raw RPM only; nothing sent when ECU is off).
+#define RPM_IGNITION_INDICATOR 0
+
+// When RPM_IGNITION_INDICATOR is enabled, the number of ignition-off (RPM 0)
+// reports to transmit after the ECU stops responding before the device enters
+// standby. Ensures the server is promptly notified that the ignition is off.
+#define IGNITION_OFF_REPORTS 3
+
 /**************************************
 * Networking configurations
 **************************************/
@@ -117,18 +129,33 @@
 #define WIFI_AP_SSID "TELELOGGER"
 #define WIFI_AP_PASSWORD "PASSWORD"
 
+// Controls how long (in seconds) the vehicle must be motionless before stepping down
+// to a slower data rate. Each value pairs with the corresponding DATA_INTERVAL_TABLE
+// entry. Once all thresholds are exceeded, the device enters standby mode.
+// Example: {60, 600, 1800} = stay at tier-1 rate for 60s, tier-2 for 10min, tier-3
+// for 30min, then standby.
+#define STATIONARY_TIME_TABLE {10, 60, 180} /* seconds */
+
+// Sets the data transmission interval for each motion tier, paired with
+// STATIONARY_TIME_TABLE. Tier 1 (moving), tier 2 (recently stopped), tier 3 (parked).
+// Example: {15, 60, 300} = every 15s while moving, every 60s when briefly
+// stopped, every 5min when parked with engine on.
+#define DATA_INTERVAL_TABLE {1, 2, 5} /* seconds */
+
+// While in standby (engine off, OBD unavailable), the device wakes periodically,
+// transmits one position packet, then returns to sleep. This controls that interval.
+// Increase to reduce data usage during long parking periods.
+#define PING_BACK_INTERVAL 900 /* seconds */
+
 // maximum consecutive communication errors before resetting network
 #define MAX_CONN_ERRORS_RECONNECT 5
-// maximum allowed connecting time
+// maximum allowed connected time
 #define MAX_CONN_TIME 10000 /* ms */
 // data receiving timeout
 #define DATA_RECEIVING_TIMEOUT 5000 /* ms */
 // expected maximum server sync signal interval
 #define SERVER_SYNC_INTERVAL 120 /* seconds, 0 to disable */
-// data interval settings
-#define STATIONARY_TIME_TABLE {10, 60, 180} /* seconds */
-#define DATA_INTERVAL_TABLE {1000, 2000, 5000} /* ms */
-#define PING_BACK_INTERVAL 900 /* seconds */
+// how often to check signal strength
 #define SIGNAL_CHECK_INTERVAL 10 /* seconds */
 
 /**************************************

--- a/firmware_v5/telelogger/telelogger.ino
+++ b/firmware_v5/telelogger/telelogger.ino
@@ -101,7 +101,7 @@ uint32_t timeoutsNet = 0;
 uint32_t lastStatsTime = 0;
 
 int32_t syncInterval = SERVER_SYNC_INTERVAL * 1000;
-int32_t dataInterval = 1000;
+int32_t dataInterval = 1;
 
 #if STORAGE != STORAGE_NONE
 int fileid = 0;
@@ -258,7 +258,15 @@ void processOBD(CBuffer* buffer)
     if (obd.readPID(pid, value)) {
         obdData[i].ts = millis();
         obdData[i].value = value;
-        buffer->add((uint16_t)pid | 0x100, ELEMENT_INT32, &value, sizeof(value));
+        int outValue = value;
+#if RPM_IGNITION_INDICATOR
+        // Encode ignition state into RPM: a responding ECU means ignition is ON,
+        // even during engine auto-stop (RPM truly 0). Remap that 0 to 1 so that
+        // rpm >= 1 always indicates ignition ON, distinct from the ignition-OFF
+        // marker (RPM 0) emitted when the ECU stops responding.
+        if (pid == PID_RPM && outValue == 0) outValue = 1;
+#endif
+        buffer->add((uint16_t)pid | 0x100, ELEMENT_INT32, &outValue, sizeof(outValue));
     } else {
         timeoutsOBD++;
         printTimeoutStats();
@@ -665,14 +673,38 @@ void process()
     if (obd.errors >= MAX_OBD_ERRORS) {
       if (!obd.init()) {
         Serial.println("[OBD] ECU OFF");
+#if RPM_IGNITION_INDICATOR
+        // Keep working a few more cycles so an ignition-off (RPM 0) report is
+        // built and transmitted before going to standby.
+        state.clear(STATE_OBD_READY);
+#else
         state.clear(STATE_OBD_READY | STATE_WORKING);
         return;
+#endif
       }
     }
   } else if (obd.init(PROTO_AUTO, true)) {
     state.set(STATE_OBD_READY);
     Serial.println("[OBD] ECU ON");
   }
+#if RPM_IGNITION_INDICATOR
+  static int ignitionOffReports = 0;
+  if (!state.check(STATE_OBD_READY)) {
+    if (ignitionOffReports >= IGNITION_OFF_REPORTS) {
+      // Enough ignition-off reports sent; let the device enter standby.
+      Serial.println("[OBD] Ignition off, entering standby");
+      state.clear(STATE_WORKING);
+      return;
+    }
+    // ECU not responding: ignition is OFF. Emit RPM 0 as an explicit ignition-off
+    // marker so the server sees rpm == 0 rather than just an absence of data.
+    int rpmOff = 0;
+    buffer->add((uint16_t)PID_RPM | 0x100, ELEMENT_INT32, &rpmOff, sizeof(rpmOff));
+    ignitionOffReports++;
+  } else {
+    ignitionOffReports = 0;
+  }
+#endif
 #endif
 
   if (rssi != rssiLast) {
@@ -769,9 +801,9 @@ void process()
   dataInterval = dataIntervals[0];
 #endif
   do {
-    long t = dataInterval - (millis() - startTime);
+    long t = dataInterval * 1000 - (millis() - startTime);
     processBLE(t > 0 ? t : 0);
-  } while (millis() - startTime < dataInterval);
+  } while (millis() - startTime < dataInterval * 1000);
 }
 
 bool initCell(bool quick = false)


### PR DESCRIPTION
## Summary

Two independent changes to the `firmware_v5/telelogger` sketch. The second is fully opt-in and **off by default**, so default behavior is unchanged except for the units fix below (which preserves the original effective timing).

### 1. Fix mismatched time units for the data interval

`dataInterval` and `DATA_INTERVAL_TABLE` were used inconsistently — the table was documented in **milliseconds** while the surrounding stationary/standby logic operates in **seconds**. This standardizes `dataInterval` on seconds and multiplies by 1000 only at the single point where a millisecond delay is actually needed.

- `DATA_INTERVAL_TABLE` is restated in seconds as `{1, 2, 5}` (equivalent to the previous `{1000, 2000, 5000} /* ms */`), so the original 1s / 2s / 5s timing is preserved.
- Initial `dataInterval` default changed from `1000` to `1` (now seconds).
- The wait loop multiplies `dataInterval * 1000` to produce the millisecond delay.

### 2. Optional RPM-based ignition indicator (off by default)

Guarded by a new `RPM_IGNITION_INDICATOR` config flag (default `0` = original behavior). When enabled, RPM becomes a reliable ignition signal for backends such as Traccar (`rpm > 0`):

- A responding ECU reporting **RPM 0** (engine auto start/stop at a stoplight) is remapped to **RPM 1**, so `rpm >0` always indicates ignition **ON**.
- When the ECU stops responding (ignition **OFF**), an explicit **RPM 0** marker is transmitted for `IGNITION_OFF_REPORTS` cycles (default 3) before the device enters standby, so the server is promptly notified rather than just seeing an absence of data.

**Motivation:** on some vehicles the battery voltage dips at idle and engine auto start/stop drives RPM to 0, which makes both voltage and raw RPM unreliable as ignition indicators. Distinguishing "ECU alive, RPM 0" (idle stop) from "ECU not responding" (ignition off) solves this.

## Changes

- `firmware_v5/telelogger/config.h`
  - Add `RPM_IGNITION_INDICATOR` (default `0`) and `IGNITION_OFF_REPORTS` (default `3`).
  - Restate `DATA_INTERVAL_TABLE` in seconds.
  - Expand comments documenting the stationary-time, data-interval and ping-back settings.
- `firmware_v5/telelogger/telelogger.ino`
  - Time-units fix described above.
  - RPM remap + ignition-off marker logic, all guarded by `#if RPM_IGNITION_INDICATOR`.

## Compatibility / risk

- With `RPM_IGNITION_INDICATOR` left at its default `0`, the ignition-indicator code is compiled out entirely.
- The time-units change is behavior-preserving (same effective intervals), but makes the table's unit match the rest of the codebase.

🤖 Generated with the assistance of [Claude Code](https://claude.com/claude-code)